### PR TITLE
Issue: Use global in menu item param 

### DIFF
--- a/administrator/com_joomgallery/src/Service/Config/Config.php
+++ b/administrator/com_joomgallery/src/Service/Config/Config.php
@@ -343,7 +343,7 @@ abstract class Config extends \stdClass implements ConfigInterface
           // set param to class property
           if(!isset($this->$key) || $value !== $this->$key)
           {
-            if($value == '-1')
+            if($value == '-1' || $value == '')
             {
               continue;
             }


### PR DESCRIPTION
When setting 'Use global' in the menu item parameters the parameter gets wrongly integrated into the config set. Therefore the parameters are not correcttly applied.

With this PR this issue should be fixed.